### PR TITLE
add dependency py-cpuinfo

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 psutil==5.7.2
 rich==6.2.0
+
+py-cpuinfo


### PR DESCRIPTION
Adicionei uma dependencia que faltava(rodei aqui no manjaro 20.1 e faltava essa dependencia)